### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,20 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [**breaking**] This is a breaking change.
-
-### Fixed
-
-- Fixing clippy warnings.
-- Fixing main.rs warning.
-
-### Other
-
-- BREAKING CHANGE: Refactoring mutable function to properly use mutable self reference instead of relying on cloning. #learning
-- Adding CHANGELOG.md.
-- Adding release-plz.yml.
-- Removing Uuid from Piece. Adding Uuid to Game.
-- Update rust.yml.
+- [**breaking**] Refactoring mutable function to properly use mutable self reference instead of
+  relying on cloning. #learning
+- [**breaking**] Removing Uuid from Piece.
+- Adding Uuid to Game.
 
 ## [0.1.0](https://github.com/OlivierPelletier/hive/releases/tag/v0.1.0) - 2024-11-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/OlivierPelletier/hive/compare/v0.1.0...v0.2.0) - 2024-11-05
+
+### Added
+
+- [**breaking**] This is a breaking change.
+
+### Fixed
+
+- Fixing clippy warnings.
+- Fixing main.rs warning.
+
+### Other
+
+- BREAKING CHANGE: Refactoring mutable function to properly use mutable self reference instead of relying on cloning. #learning
+- Adding CHANGELOG.md.
+- Adding release-plz.yml.
+- Removing Uuid from Piece. Adding Uuid to Game.
+- Update rust.yml.
+
 ## [0.1.0](https://github.com/OlivierPelletier/hive/releases/tag/v0.1.0) - 2024-11-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "hive-engine"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive-engine"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Olivier Pelletier <olivier.op@outlook.com>"]
 edition = "2021"
 rust-version = "1.82"


### PR DESCRIPTION
## 🤖 New release
* `hive-engine`: 0.1.0 -> 0.2.0 (⚠️ API breaking changes)

### ⚠️ `hive-engine` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Game.id in /tmp/.tmpe1HLe6/hive/src/engine/game.rs:19

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/inherent_method_missing.ron

Failed in:
  Game::tournement, previously in file /tmp/.tmp5yPBrV/hive-engine/src/engine/game.rs:23

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field id of struct Piece, previously in file /tmp/.tmp5yPBrV/hive-engine/src/engine/grid/piece.rs:54
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/OlivierPelletier/hive/compare/v0.1.0...v0.2.0) - 2024-11-05

### Added

- [**breaking**] This is a breaking change.

### Fixed

- Fixing clippy warnings.
- Fixing main.rs warning.

### Other

- BREAKING CHANGE: Refactoring mutable function to properly use mutable self reference instead of relying on cloning. #learning
- Adding CHANGELOG.md.
- Adding release-plz.yml.
- Removing Uuid from Piece. Adding Uuid to Game.
- Update rust.yml.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).