### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/OlivierPelletier/hive/compare/v0.3.0...v0.3.1) - 2026-05-06
+
+### Other
+
+- README.md update
+
 ## [0.3.0](https://github.com/OlivierPelletier/hive/compare/v0.2.0...v0.3.0) - 2026-05-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "hive-engine"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive-engine"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Olivier Pelletier <olivier.op@outlook.com>"]
 edition = "2024"
 rust-version = "1.94"


### PR DESCRIPTION



## 🤖 New release

* `hive-engine`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/OlivierPelletier/hive/compare/v0.3.0...v0.3.1) - 2026-05-06

### Other

- README.md update
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).