### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/OlivierPelletier/hive/compare/v0.3.0...v0.4.0) - 2026-07-17
+
+### Added
+
+- QoL changes, fixing typos and some minor refactoring for performance
+
+### Fixed
+
+- fixing freedom to move rule with stacked pieces and ladybug movement
+- sorting player actions before returning
+
+### Other
+
+- shortcutting one_hive_rule algorithm
+- todos
+- applying rustfmt
+- README.md update
+
 ## [0.3.0](https://github.com/OlivierPelletier/hive/compare/v0.2.0...v0.3.0) - 2026-05-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
 
 [[package]]
 name = "hive-engine"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive-engine"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Olivier Pelletier <olivier.op@outlook.com>"]
 edition = "2024"
 rust-version = "1.94"


### PR DESCRIPTION



## 🤖 New release

* `hive-engine`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `hive-engine` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Game.is_tournament_rule in /tmp/.tmpfu0YwZ/hive/src/engine/game.rs:45
  field Grid.cells in /tmp/.tmpfu0YwZ/hive/src/engine/grid.rs:20

--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type Player no longer derives Clone, in /tmp/.tmpfu0YwZ/hive/src/engine/game/player.rs:4

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/function_missing.ron

Failed in:
  function hive::engine::moves::grasshoper::grasshopper_moves, previously in file /tmp/.tmp1KmnqC/hive-engine/src/engine/moves/grasshoper.rs:11

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/module_missing.ron

Failed in:
  mod hive::engine::moves::grasshoper, previously in file /tmp/.tmp1KmnqC/hive-engine/src/engine/moves/grasshoper.rs:1

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field is_tournement_rule of struct Game, previously in file /tmp/.tmp1KmnqC/hive-engine/src/engine/game.rs:44
  field grid of struct Grid, previously in file /tmp/.tmp1KmnqC/hive-engine/src/engine/grid.rs:20
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/OlivierPelletier/hive/compare/v0.3.0...v0.4.0) - 2026-07-17

### Added

- QoL changes, fixing typos and some minor refactoring for performance

### Fixed

- fixing freedom to move rule with stacked pieces and ladybug movement
- sorting player actions before returning

### Other

- shortcutting one_hive_rule algorithm
- todos
- applying rustfmt
- README.md update
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).